### PR TITLE
fix(cli): arrayify splits comma-separated strings

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -184,7 +184,7 @@ function getAttributeContentsToLocalize(dom, attributesArray, attributeSetter, a
 
 function arrayify(unknown) {
   if (typeof unknown === 'string') {
-    return [unknown];
+    return unknown.split(',');
   }
   return unknown;
 }


### PR DESCRIPTION
issue 8: CLI specifying elements via -e fails
