### PR TITLE
Added sort option to disable the extract locales sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,9 @@ S18n will trim whitespace from each string (using javascript's `String.prototype
 
 Based on this option, the `extract` method returns the extracted locale as a javascript object or as a formatted JSON string.
 
-#### sort
-- Accepts: `true` or `false`
-- Default: `true`
+#### unsorted
 
-Based on this option, the `extract` and `extractFiles` methods returns a sorted/unsorted extracted locale.
+Based on this option, the `extract` and `extractFiles` methods returns an unsorted extracted locale.
 
 ## Localize
 To localize html, s18n searches through the html for strings in the `nativeLocale`, replacing them with the localized strings in each locale. S18n only matches strings in locations from which they could have been extracted (between `""`, `''`, and `><`) to avoid translating unintended strings.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ S18n will trim whitespace from each string (using javascript's `String.prototype
 
 Based on this option, the `extract` method returns the extracted locale as a javascript object or as a formatted JSON string.
 
+#### sort
+- Accepts: `true` or `false`
+- Default: `true`
+
+Based on this option, the `extract` and `extractFiles` methods returns a sorted/unsorted extracted locale.
+
 ## Localize
 To localize html, s18n searches through the html for strings in the `nativeLocale`, replacing them with the localized strings in each locale. S18n only matches strings in locations from which they could have been extracted (between `""`, `''`, and `><`) to avoid translating unintended strings.
 

--- a/bin/s18n-extract
+++ b/bin/s18n-extract
@@ -14,7 +14,7 @@ program
   .option('--hash <algo>', 'hashing algorithm to calculate string IDs [default: md5]')
   .option('--length <length>', 'length of string IDs [default: 8]')
   .option('--format <type>', 'format in which to return the locale, "object" or (JSON) "string" [default: \'string\']')
-  .option('--unsorted', 'return an unsorted locale [default: \'false\']');
+  .option('--unsorted', 'return an unsorted extracted locale');
 
 program.on('--help', function() {
   console.log('  Examples:');

--- a/bin/s18n-extract
+++ b/bin/s18n-extract
@@ -13,7 +13,8 @@ program
   .option('-s, --string <html>', 'extract from string of parsable html')
   .option('--hash <algo>', 'hashing algorithm to calculate string IDs [default: md5]')
   .option('--length <length>', 'length of string IDs [default: 8]')
-  .option('--format <type>', 'format in which to return the locale, "object" or (JSON) "string" [default: \'string\']');
+  .option('--format <type>', 'format in which to return the locale, "object" or (JSON) "string" [default: \'string\']')
+  .option('--unsorted', 'return an unsorted locale [default: \'false\']');
 
 program.on('--help', function() {
   console.log('  Examples:');
@@ -55,7 +56,8 @@ var map = {
   elements: 'elements',
   hash: 'hashAlgorithm',
   length: 'hashLength',
-  format: 'output'
+  format: 'output',
+  unsorted: 'unsorted'
 };
 
 for (var key in map) {

--- a/bin/s18n-localize
+++ b/bin/s18n-localize
@@ -15,7 +15,7 @@ program
   .option('-n, --native <path>', 'path to native locale file [default: \'locales/en.json\']')
   .option('-p, --paths [paths]', 'paths or patterns (globby) to find localizable html files [default: \'**/*.html\']')
   .option('-o, --output <path>', 'directory in which to output localized html files [default: \'./\']')
-  .option('-s, --sort <type>', 'return a sorted or unsorted locale [default: \'true\']')
+  .option('-u, --unsorted', 'return an unsorted locale')
   .option('-q, --quiet', 'suppress logging information');
 
 program.on('--help', function() {

--- a/bin/s18n-localize
+++ b/bin/s18n-localize
@@ -37,7 +37,7 @@ var options = {
   paths: '**/*.html',
   output: './',
   quiet: false,
-  sort: true
+  unsorted: false
 };
 console.log(options);
 

--- a/bin/s18n-localize
+++ b/bin/s18n-localize
@@ -15,6 +15,7 @@ program
   .option('-n, --native <path>', 'path to native locale file [default: \'locales/en.json\']')
   .option('-p, --paths [paths]', 'paths or patterns (globby) to find localizable html files [default: \'**/*.html\']')
   .option('-o, --output <path>', 'directory in which to output localized html files [default: \'./\']')
+  .option('-s, --sort <type>', 'return a sorted or unsorted locale [default: \'true\']')
   .option('-q, --quiet', 'suppress logging information');
 
 program.on('--help', function() {
@@ -35,8 +36,10 @@ var options = {
   native: 'locales/en.json',
   paths: '**/*.html',
   output: './',
-  quiet: false
+  quiet: false,
+  sort: true
 };
+console.log(options);
 
 // override defaults with user input
 for (var id in options) {

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -23,7 +23,7 @@ module.exports = function(html, options) {
   options.hashLength = options.hashLength || 8;
   options.trimWhitespace = options.trimWhitespace === false ? false : true;
   options.output = options.output || 'object';
-  options.sort = typeof options.sort === 'boolean' ? options.sort : true;
+  options.unsorted = options.unsorted === true ? options.unsorted : false;
 
   var locale = {};
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -23,6 +23,7 @@ module.exports = function(html, options) {
   options.hashLength = options.hashLength || 8;
   options.trimWhitespace = options.trimWhitespace === false ? false : true;
   options.output = options.output || 'object';
+  options.sort = typeof options.sort === 'boolean' ? options.sort : true;
 
   var locale = {};
 
@@ -76,9 +77,7 @@ module.exports = function(html, options) {
   parser.write(html);
   parser.done();
 
-  return s18n.formatLocale(locale, {
-    output: options.output
-  });
+  return s18n.formatLocale(locale, options);
 };
 
 function getElementsContentsToLocalize(dom, elementsArray, directivesArray, cancelersArray) {

--- a/lib/extractFiles.js
+++ b/lib/extractFiles.js
@@ -33,9 +33,8 @@ module.exports = function(patterns, options) {
           }
         })
         .then(function() {
-          var formattedLocale = s18n.formatLocale(fullLocale, {
-            output: finalOutputType
-          });
+          options.output = finalOutputType;
+          var formattedLocale = s18n.formatLocale(fullLocale, options);
           resolve(formattedLocale);
         })
         .catch(function(err) {

--- a/lib/formatLocale.js
+++ b/lib/formatLocale.js
@@ -9,8 +9,8 @@ module.exports = function(locale, options) {
   if (typeof options.output === 'undefined') {
     options.output = 'object';
   }
-  if (typeof options.sort === 'undefined') {
-    options.sort = true;
+  if (typeof options.unsorted === 'undefined') {
+    options.unsorted = false;
   }
 
   var strings = [];
@@ -20,7 +20,7 @@ module.exports = function(locale, options) {
       string: locale[hash]
     });
   }
-  if (options.sort === true) {
+  if (options.unsorted === false) {
     // strings are ordered alphabetically for better readability & source control
     strings.sort(function(a, b) {
       if (a.string.toLowerCase() < b.string.toLowerCase()) {

--- a/lib/formatLocale.js
+++ b/lib/formatLocale.js
@@ -20,7 +20,7 @@ module.exports = function(locale, options) {
       string: locale[hash]
     });
   }
-  if (options.sortLocales === true) {
+  if (options.sort === true) {
     // strings are ordered alphabetically for better readability & source control
     strings.sort(function(a, b) {
       if (a.string.toLowerCase() < b.string.toLowerCase()) {

--- a/lib/formatLocale.js
+++ b/lib/formatLocale.js
@@ -9,6 +9,9 @@ module.exports = function(locale, options) {
   if (typeof options.output === 'undefined') {
     options.output = 'object';
   }
+  if (typeof options.sort === 'undefined') {
+    options.sort = true;
+  }
 
   var strings = [];
   for (var hash in locale) {
@@ -17,16 +20,18 @@ module.exports = function(locale, options) {
       string: locale[hash]
     });
   }
-  // strings are ordered alphabetically for better readability & source control
-  strings.sort(function(a, b) {
-    if (a.string.toLowerCase() < b.string.toLowerCase()) {
-      return -1;
-    }
-    if (a.string.toLowerCase() > b.string.toLowerCase()) {
-      return 1;
-    }
-    return 0;
-  });
+  if (options.sortLocales === true) {
+    // strings are ordered alphabetically for better readability & source control
+    strings.sort(function(a, b) {
+      if (a.string.toLowerCase() < b.string.toLowerCase()) {
+        return -1;
+      }
+      if (a.string.toLowerCase() > b.string.toLowerCase()) {
+        return 1;
+      }
+      return 0;
+    });
+  }
   var sortedLocale = {};
   for (var i = 0; i < strings.length; i++) {
     sortedLocale[strings[i].hash] = strings[i].string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s18n",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Semantic localization for html.",
   "main": "lib/s18n.js",
   "bin": {

--- a/test/spec.extract.js
+++ b/test/spec.extract.js
@@ -151,7 +151,7 @@ describe('s18n.extract()', function() {
 
   it('should return an unsorted locale object', function() {
     var html = '<p>String A</p><p>String C</p><p>String B</p>';
-    var locale = s18n.extract(html, {sort: false});
+    var locale = s18n.extract(html, {unsorted: true});
     var count = 0;
     var ordered = ['String A', 'String C', 'String B'];
     for (var number in locale) {

--- a/test/spec.extract.js
+++ b/test/spec.extract.js
@@ -149,4 +149,15 @@ describe('s18n.extract()', function() {
     }
   });
 
+  it('should return an unsorted locale object', function() {
+    var html = '<p>String A</p><p>String C</p><p>String B</p>';
+    var locale = s18n.extract(html, {sort: false});
+    var count = 0;
+    var ordered = ['String A', 'String C', 'String B'];
+    for (var number in locale) {
+      assert.equal(locale[number], ordered[count]);
+      count++;
+    }
+  });
+
 });

--- a/test/spec.formatLocale.js
+++ b/test/spec.formatLocale.js
@@ -46,7 +46,7 @@ describe('s18n.formatLocale()', function() {
     };
     var formatedLocale = s18n.formatLocale(locale, {
       output: 'string',
-      sort: false
+      unsorted: true
     });
     assert.equal(formatedLocale, '{\n  "acbd18db": "foo",\n  "37b51d19": "bar",\n  "73feffa4": "baz"\n}');
   });
@@ -58,7 +58,7 @@ describe('s18n.formatLocale()', function() {
       '37b51d19': 'bar',
       '73feffa4': 'baz'
     };
-    var formatedLocale = s18n.formatLocale(locale, {sort: false});
+    var formatedLocale = s18n.formatLocale(locale, {unsorted: true});
     var count = 0;
     var ordered = ['foo', 'foo', 'bar', 'baz'];
     for (var number in formatedLocale) {

--- a/test/spec.formatLocale.js
+++ b/test/spec.formatLocale.js
@@ -38,6 +38,35 @@ describe('s18n.formatLocale()', function() {
     }
   });
 
+  it('should return and unsorted locale as a string', function() {
+    var locale = {
+      'acbd18db': 'foo',
+      '37b51d19': 'bar',
+      '73feffa4': 'baz'
+    };
+    var formatedLocale = s18n.formatLocale(locale, {
+      output: 'string',
+      sort: false
+    });
+    assert.equal(formatedLocale, '{\n  "acbd18db": "foo",\n  "37b51d19": "bar",\n  "73feffa4": "baz"\n}');
+  });
+
+  it('should return an unsorted locale as an object', function() {
+    var locale = {
+      'acbd18db': 'foo',
+      'badhash': 'foo',
+      '37b51d19': 'bar',
+      '73feffa4': 'baz'
+    };
+    var formatedLocale = s18n.formatLocale(locale, {sort: false});
+    var count = 0;
+    var ordered = ['foo', 'foo', 'bar', 'baz'];
+    for (var number in formatedLocale) {
+      assert.equal(formatedLocale[number], ordered[count]);
+      count++;
+    }
+  });
+
   it('should throw an error if output option is unrecognized', function() {
     assert.throws(
       function() {

--- a/test/spec.formatLocale.js
+++ b/test/spec.formatLocale.js
@@ -38,7 +38,7 @@ describe('s18n.formatLocale()', function() {
     }
   });
 
-  it('should return and unsorted locale as a string', function() {
+  it('should return an unsorted locale as a string', function() {
     var locale = {
       'acbd18db': 'foo',
       '37b51d19': 'bar',


### PR DESCRIPTION
This pull request just add a new boolean option `sort`.

```js
var opts = {
    native: 'english',
    elements: [],
    attributes: ['alt', 'title', 'placeholder'],
    sort: false
};

s18n.extractFiles(file, opts)
    .then(function(locale) {
        console.log(locale);
    });
```

The default value of the option is `true`, witch keep the plugin original behavior unchanged.

Declaring the option `sort` to `false` will just disable the sorting algorithm on `lib/formatLocale.js` script.

### Use case

The objective of this changes, is to be able to extract native locales from an HTML page, and keep the same order, as in the source page.

This make it easy for sending the locale files for translation to a different developing team. As they will need to visually match the original copy with the source page.


Best regards!